### PR TITLE
removed faulty option of package in document style

### DIFF
--- a/exercise_sheets/sheet.cls
+++ b/exercise_sheets/sheet.cls
@@ -95,7 +95,7 @@
 \RequirePackage{cleveref}
 \RequirePackage{calc}
 
-\RequirePackage[outputdir=out/aux]{minted}
+\RequirePackage{minted}
 \usemintedstyle{lovelace}
 \setminted{fontsize=\small, autogobble=true, bgcolor=TUMBlue!5!TUMWhite, breaklines=true}
 


### PR DESCRIPTION
Removed option [outputdir=out/aux] since the ouput path has to match the Pygmentize working directory; the default setting (i.e. not specifying the options) is the working dir and it seems to work that way